### PR TITLE
fix: bump cw-orch version to 0.22.2. Minor changes suggestions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ schemars = "0.8.10"
 thiserror = { version = "1.0.21" }
 
 
-cw-orch = { version = "0.22.0" }
+cw-orch = { version = "0.22.2" }
 cw721-base = { git = "http://github.com/AbstractSDK/cw-nfts.git", version = "0.18.0", features = [
     "library",
 ] }

--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -8,7 +8,7 @@ use cw_utils::one_coin;
 use crate::{error::*, execute::_mint, msg::*, query::query_state, state::*};
 
 // version info for migration info
-pub const CONTRACT_NAME: &str = "crates.io:counter";
+pub const CONTRACT_NAME: &str = "crates.io:cw721_minter";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg_attr(feature = "export", entry_point)]

--- a/contracts/minter/src/interface.rs
+++ b/contracts/minter/src/interface.rs
@@ -10,7 +10,7 @@ use cw_plus_interface::cw20_base::{self, Cw20Base};
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::{MinterExecuteMsgFns, MinterQueryMsgFns};
 
-pub const CONTRACT_ID: &str = "counter_contract";
+pub const CONTRACT_ID: &str = "cw721_minter";
 
 #[interface(InstantiateMsg, ExecuteMsg, QueryMsg, MigrateMsg, id = CONTRACT_ID)]
 pub struct MinterContract;
@@ -19,7 +19,7 @@ impl<Chain> Uploadable for MinterContract<Chain> {
     /// Return the path to the wasm file corresponding to the contract
     fn wasm(_chain: &ChainInfoOwned) -> WasmPath {
         artifacts_dir_from_workspace!()
-            .find_wasm_path("cw721_minter")
+            .find_wasm_path(CONTRACT_ID)
             .unwrap()
     }
 


### PR DESCRIPTION
## Description

When running the tests, on Quest #3.1 (test `test_upload_test_tube`) an error occur: 

- `Can't wait blocks on osmosis_test_tube`

## Problem analysis

- The quest branch uses cw-orch = { version = "0.22.0" } which doesn't impl the `fn wait_blocks`. This fn is already impl in version 0.22.2.

## Solution

- Bump cw-orch version from 0.22.0 to 0.22.2.

## Note

- Also update the `CONTRACT_NAME` on the minter smart contract to differentiate from the counter smart contract. This is not need it.
- the `.env.example` file uses `STATE_FILE="/root/abstract/cw-orch-workshop/contracts/minter/state.json"` which cargo need root permission to write/update it. It could be replaced as `STATE_FILE="./state.json"` to avoid the problem. 